### PR TITLE
feat(auth): implement account linking with unsecure config and custom hasCredentials parameter

### DIFF
--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -6,6 +6,7 @@ export type ExtendedUser = DefaultSession["user"] & {
   role: UserRole | null;
   isTwoFactorEnabled: boolean;
   isOAuth: boolean;
+  hasCredentials: boolean;
 };
 
 declare module "next-auth" {

--- a/src/actions/change-oauth-account.ts
+++ b/src/actions/change-oauth-account.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { db } from "~/server/db";
+import { currentUser } from "~/lib/authentication";
+
+interface ChangeOAuthAccountParams {
+  provider: "google";
+}
+
+export async function changeOAuthAccount({
+  provider,
+}: ChangeOAuthAccountParams) {
+  const user = await currentUser();
+
+  if (!user) {
+    return { error: "No autorizado." };
+  }
+
+  if (!provider) {
+    return { error: "Debe indicar un proveedor OAuth." };
+  }
+
+  await db.account.deleteMany({
+    where: {
+      userId: user.id,
+      provider,
+    },
+  });
+
+  return { success: true };
+}

--- a/src/actions/sign-up.ts
+++ b/src/actions/sign-up.ts
@@ -46,9 +46,6 @@ export async function signUp(values: z.infer<typeof SignUpSchema>) {
 
   const verificationToken = await generateVerificationToken(newUser.id);
 
-  // const verifyLink = `http://localhost:3000/auth/email-verification?token=${verificationToken.token}`;
-  // console.log(`Verification link: ${verifyLink}`);
-
   await sendVerificationEmail(
     newUser.name,
     newUser.email,

--- a/src/actions/update-password.ts
+++ b/src/actions/update-password.ts
@@ -17,7 +17,7 @@ export async function updatePassword(
     return { error: "No autorizado." };
   }
 
-  if (user.isOAuth) {
+  if (!user.hasCredentials) {
     return { error: "No autorizado." };
   }
 

--- a/src/actions/update-profile.ts
+++ b/src/actions/update-profile.ts
@@ -30,6 +30,8 @@ export async function updateProfile(
     updateEmail = true;
   }
 
+  console.log("updateEmail: ", updateEmail);
+
   if (updateEmail) {
     const existingUser = await getUserByEmail(values.email);
 
@@ -52,7 +54,7 @@ export async function updateProfile(
     },
     data: {
       name: values.name,
-      tempEmail: !user.hasCredentials || updateEmail ? undefined : values.email,
+      tempEmail: user.hasCredentials || updateEmail ? values.email : undefined,
       role: values.role,
       isTwoFactorEnabled: user.hasCredentials
         ? values.isTwoFactorEnabled

--- a/src/actions/update-profile.ts
+++ b/src/actions/update-profile.ts
@@ -52,9 +52,11 @@ export async function updateProfile(
     },
     data: {
       name: values.name,
-      tempEmail: user.isOAuth || !updateEmail ? undefined : values.email,
+      tempEmail: !user.hasCredentials || updateEmail ? undefined : values.email,
       role: values.role,
-      isTwoFactorEnabled: user.isOAuth ? undefined : values.isTwoFactorEnabled,
+      isTwoFactorEnabled: user.hasCredentials
+        ? values.isTwoFactorEnabled
+        : undefined,
     },
   });
 

--- a/src/app/(test)/settings/page.tsx
+++ b/src/app/(test)/settings/page.tsx
@@ -1,4 +1,5 @@
 import { UserCog } from "lucide-react";
+import UpdateOauth from "~/components/auth/update-oauth";
 
 import UpdatePasswordForm from "~/components/auth/update-password-form";
 import UpdateProfileForm from "~/components/auth/update-profile-form";
@@ -26,6 +27,16 @@ export default async function SettingsPage() {
           <UpdateProfileForm />
         </CardContent>
       </Card>
+      {user?.isOAuth === true && (
+        <Card className="mt-6 w-full">
+          <CardHeader>
+            <h3 className="font-semibold">Actualizar OAuth</h3>
+          </CardHeader>
+          <CardContent>
+            <UpdateOauth />
+          </CardContent>
+        </Card>
+      )}
       {user?.hasCredentials === true && (
         <Card className="mt-6 w-full">
           <CardHeader>

--- a/src/app/(test)/settings/page.tsx
+++ b/src/app/(test)/settings/page.tsx
@@ -26,7 +26,7 @@ export default async function SettingsPage() {
           <UpdateProfileForm />
         </CardContent>
       </Card>
-      {user?.isOAuth === false && (
+      {user?.hasCredentials === true && (
         <Card className="mt-6 w-full">
           <CardHeader>
             <h3 className="font-semibold">Actualizar contraseña</h3>

--- a/src/components/auth/update-oauth.tsx
+++ b/src/components/auth/update-oauth.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useCurrentUser } from "~/hooks/use-current-user";
+import { Button } from "../ui/button";
+import { useTransition } from "react";
+import { changeOAuthAccount } from "~/actions/change-oauth-account";
+import { signIn as authSignIn } from "next-auth/react";
+import { DEFAULT_SIGNIN_REDIRECT } from "@/routes";
+
+export default function UpdateOauth() {
+  const user = useCurrentUser();
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    user?.isOAuth === true && (
+      <Button
+        type="button"
+        disabled={isPending || !user?.isOAuth}
+        className="w-full"
+        onClick={() =>
+          startTransition(async () => {
+            const res = await changeOAuthAccount({ provider: "google" });
+            if (res.error) return;
+            await authSignIn("google", {
+              callbackUrl: DEFAULT_SIGNIN_REDIRECT,
+            });
+          })
+        }
+      >
+        Cambiar cuenta de Google
+      </Button>
+    )
+  );
+}

--- a/src/components/auth/update-password-form.tsx
+++ b/src/components/auth/update-password-form.tsx
@@ -61,7 +61,7 @@ export default function UpdatePasswordForm() {
     <Form {...form}>
       <form className="space-y-6" onSubmit={form.handleSubmit(onSubmit)}>
         <div className="space-y-4">
-          {user?.isOAuth === false && (
+          {user?.hasCredentials === true && (
             <>
               <FormField
                 control={form.control}

--- a/src/components/auth/update-profile-form.tsx
+++ b/src/components/auth/update-profile-form.tsx
@@ -110,7 +110,7 @@ export default function UpdateProfileForm() {
             )}
           />
 
-          {user?.isOAuth === false && (
+          {user?.hasCredentials === true && (
             <FormField
               control={form.control}
               name="email"
@@ -179,7 +179,7 @@ export default function UpdateProfileForm() {
             )}
           />
 
-          {user?.isOAuth === false && (
+          {user?.hasCredentials === true && (
             <FormField
               control={form.control}
               name="isTwoFactorEnabled"

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -87,9 +87,8 @@ export const authConfig = {
   callbacks: {
     async signIn({ user, account }: { user: User; account?: Account | null }) {
       if (
-        !account ||
-        typeof account.email !== "string" ||
-        !account.email.endsWith("@sanignacio.edu.uy")
+        typeof user.email !== "string" ||
+        !user.email.endsWith("@sanignacio.edu.uy")
       ) {
         // The email domain should be sanignacio.edu.uy and email should be a string
         return false;

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -33,6 +33,7 @@ declare module "next-auth" {
       role: UserRole | null;
       isTwoFactorEnabled: boolean;
       isOAuth: boolean;
+      hasCredentials: boolean;
     } & DefaultSession["user"];
   }
 }
@@ -44,7 +45,9 @@ declare module "next-auth" {
  */
 export const authConfig = {
   providers: [
-    GoogleProvider,
+    GoogleProvider({
+      allowDangerousEmailAccountLinking: true,
+    }),
     CredentialsProvider({
       async authorize(credentials) {
         const validatedFields = SignInSchema.safeParse(credentials);
@@ -141,6 +144,7 @@ export const authConfig = {
         session.user.email = token.email as string;
         session.user.tempEmail = token.tempEmail as string | null;
         session.user.isOAuth = token.isOAuth as boolean;
+        session.user.hasCredentials = token.hasCredentials as boolean;
       }
 
       return session;
@@ -159,6 +163,7 @@ export const authConfig = {
       const existingAccount = await getAccountByUserId(existingUser.id);
 
       token.isOAuth = !!existingAccount;
+      token.hasCredentials = !!existingUser.password;
       token.name = existingUser.name;
       token.email = existingUser.email;
       token.tempEmail = existingUser.tempEmail;


### PR DESCRIPTION
- Enabled account linking using the unsecure configuration in NextAuth.js.
- Added `hasCredentials` as a custom parameter to the Credentials provider.
- Updated authentication flow to support multiple sign-in methods.

### Notes

- Changing a user's email while their Google account is linked causes conflicts. The Google account should be unlinked before updating the email to avoid authentication errors.